### PR TITLE
Add a Dead End Message for an Unproperly Linked Option

### DIFF
--- a/english/normal-dungeon/3/2-2.md
+++ b/english/normal-dungeon/3/2-2.md
@@ -1,0 +1,5 @@
+You go to the backyard of your house 🏡 and opens the door 🚪 slightly. Suddenly, two goblins 👺👺 emerged from inside and finished you with their sharp sword ⚔️.
+
+THE END! 🎬
+
+[🔄 Restart the game](../begin-journey.md)

--- a/english/normal-dungeon/3/2.md
+++ b/english/normal-dungeon/3/2.md
@@ -2,6 +2,6 @@ As you approach your home, the 🚪door is ajar, ever so slightly, 🕯candlight
 
 ⚔️[Approach the door from the front?](3.md)
 
-🏰[Sneak around and enter from the back?](../begin-journey.md)
+🏰[Sneak around and enter from the back?](2-2.md)
 
 ❔[Go to your neighbour's first and ask if they witnessed anything](3-1.md)


### PR DESCRIPTION
There was an option in the game that linked to the `begin-journey.md` file without any dead end message.

The path:

Start a new game > I choose you, the normal dungeon > Begin Your Journey > Find a Way Out > Go Home > Something seems amiss, so you venture forth with an uneasiness of what may lie ahead > Sneak around and enter from the back?

Fix: Added a Dead End file namely `2-2.md` and linked it properly to the unlinked option.

Addresses #107 