### PR TITLE
Fix All Broken Links in Covid-19 Dungeon

### DIFF
--- a/english/covid-19/0/0-DA.md
+++ b/english/covid-19/0/0-DA.md
@@ -4,4 +4,4 @@ You try to exercise once more, but you are very much tired.
 
 [Find a way out](../WIP.md)
 
-[Go into dungeon](1.md)
+[Go into dungeon](../1/1.md)

--- a/english/covid-19/0/0-DD.md
+++ b/english/covid-19/0/0-DD.md
@@ -4,4 +4,4 @@ Great! Which book will you read?
 
 [The Invisible Man](../WIP.md)
 
-[Go into dungeon](1.md)
+[Go into dungeon](../1/1.md)

--- a/english/covid-19/1/1-CB.md
+++ b/english/covid-19/1/1-CB.md
@@ -2,4 +2,4 @@ You fought the figures. Wow! Are you the next Bruce Lee? You killed every figure
 
 [Chase the rest of the figures](../WIP.md)
 
-[Go into the dungeon](../WIP.md)
+[Go into the dungeon](../3/3.md)

--- a/english/covid-19/3/3.md
+++ b/english/covid-19/3/3.md
@@ -4,4 +4,4 @@ You cautiously opened the door to the dungeon and stepped inside. It was terribl
 
 [Walk more deeply into the dungeon](3-AB.md)
 
-[Get out of the dungeon](3.md)
+[Get out of the dungeon](../WIP.md)


### PR DESCRIPTION
There were a few broken links in the covid-19 dungeon. Also, no documents were linked to the `3/3.md`. So, added a link for that in `1/1-CB.md`.