### PR TITLE
Fix: "gurad" to "guard" typo

### DIFF
--- a/english/sci-fi-dungeon/1/1-B.md
+++ b/english/sci-fi-dungeon/1/1-B.md
@@ -2,7 +2,7 @@
 > shifting prisoner 66 to cell B-628. Requesting cell access.
 
 Now you are shifted to a new cell where other prisoners are kept. 
-Everyone is staring at you, but you saw a familiar face. You walk towards him and booom!!. You find your childhood friend Ash. You both decide to escape the prison with help of a gurad whom Ash knows. 
+Everyone is staring at you, but you saw a familiar face. You walk towards him and booom!!. You find your childhood friend Ash. You both decide to escape the prison with help of a guard whom Ash knows. 
 At night a guard came and opened gates for you and Ash.
 *guard goes back to its position. You take the spaceship map and your attention goes to control room and spaceship's parking area.*
 


### PR DESCRIPTION
The word "guard" was written as "gurad". The typo was fixed.